### PR TITLE
Fix typo at 'Installation Instructions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In order for the app to function correctly, the user must set up their own envir
 
 - Clone this Repository to your local machine
 - Use `yarn install` to install dependencies
-- User `yarn start` to start development server
+- Use `yarn start` to start development server
 
 
 # Contributing


### PR DESCRIPTION
There was a small typo at this particular section that i just couldn't manage to take my mind off of.